### PR TITLE
Bug non equal description fields

### DIFF
--- a/src/geotexxx/gefxml_reader.py
+++ b/src/geotexxx/gefxml_reader.py
@@ -1317,7 +1317,10 @@ class Bore(Test):
         except:
             pass
 
-        # zet de data om in een dataframe, dan kunnen we er wat mee    
+        # zet de data om in een dataframe, dan kunnen we er wat mee
+        self.soillayers['veld'] = self.soillayers['veld'].rstrip("\n") # remove possible end of line characters that give error
+        if not self._has_equal_borehole_fields():
+            self._fill_description_fields()
         self.soillayers['veld'] = pd.read_csv(StringIO(self.soillayers['veld']), sep=self.columnseparator, skipinitialspace=True, header=None)
 
         # vervang de dummy waarden door nan
@@ -1342,6 +1345,28 @@ class Bore(Test):
         self.finaldepth = self.soillayers['veld']["upper_NAP"].max() - self.soillayers['veld']["lower_NAP"].min()
 
         self.soillayers = self.add_components_NEN()
+    
+    def _has_equal_borehole_fields(self):
+        """Private method to assess if the number of borehole fields are equal for every description when parsing the borehole"""
+        soillayers_split = [line.split(self.columnseparator) for line in self.soillayers['veld'].split("\n")]
+        lengths = [len(line) for line in soillayers_split]
+        max_length = max(lengths)
+        return all(l == max_length for l in lengths)
+
+    def _fill_description_fields(self):
+        """If the number of fields is not equal for every description, the entrees with less fields will be filled up."""
+        soillayers_split = [line.split(self.columnseparator) for line in self.soillayers['veld'].split("\n")]
+        max_length = max(len(line) for line in soillayers_split)
+        fixed_length_soil_layers: list[str] = []
+        for layer in soillayers_split:
+            if len(layer) != max_length:
+                n_colon = max_length - len(layer)
+                fixed_length_str: str = self.columnseparator.join(layer[:-1]) + self.columnseparator * (n_colon + 1) + layer[-1]
+                fixed_length_soil_layers.append(fixed_length_str)
+            else:
+                fixed_length_soil_layers.append(self.columnseparator.join(layer))
+        fixed_length_soil_layers = "\n".join(fixed_length_soil_layers)
+        self.soillayers['veld'] = fixed_length_soil_layers
 
     def add_components_NEN(self):
         """Converts coded soil layers into data that can be plotted

--- a/src/geotexxx/gefxml_reader.py
+++ b/src/geotexxx/gefxml_reader.py
@@ -1319,6 +1319,9 @@ class Bore(Test):
 
         # zet de data om in een dataframe, dan kunnen we er wat mee
         self.soillayers['veld'] = self.soillayers['veld'].rstrip("\n") # remove possible end of line characters that give error
+        
+        # check if all fields in the borehole description have the same length
+        # if they do not have the same length, add column separators to have equal amount of column separators in every row
         if not self._has_equal_borehole_fields():
             self._fill_description_fields()
         self.soillayers['veld'] = pd.read_csv(StringIO(self.soillayers['veld']), sep=self.columnseparator, skipinitialspace=True, header=None)
@@ -1351,6 +1354,8 @@ class Bore(Test):
         soillayers_split = [line.split(self.columnseparator) for line in self.soillayers['veld'].split("\n")]
         lengths = [len(line) for line in soillayers_split]
         max_length = max(lengths)
+        # check if all rows in the borehole have the same amount of fields as the maximum length row
+        # if not all rows have the the same amount of fields as the maximum, they need to be filled to the maximum amount for parsing
         return all(l == max_length for l in lengths)
 
     def _fill_description_fields(self):

--- a/tests/borehole-files/test_borehole_non_equal_description_field.gef
+++ b/tests/borehole-files/test_borehole_non_equal_description_field.gef
@@ -1,0 +1,57 @@
+#GEFID = 1,1,0
+#COLUMNTEXT = 1, aan
+#COLUMNSEPARATOR = ;
+#RECORDSEPARATOR = !
+#FILEOWNER = DINO
+#COMPANYID = Onbekend
+#FILEDATE = 2023,1,24
+#PROJECTID = DINO-BOR
+#COLUMN = 9
+#COLUMNINFO = 1, m, Diepte bovenkant laag, 1
+#COLUMNINFO = 2, m, Diepte onderkant laag, 2
+#COLUMNINFO = 3, mm, Zandmediaan, 8
+#COLUMNINFO = 4, mm, Grindmediaan, 9
+#COLUMNINFO = 5, %, Lutum percentage, 3
+#COLUMNINFO = 6, %, Silt percentage, 4
+#COLUMNINFO = 7, %, Zand percentage, 5
+#COLUMNINFO = 8, %, Grind percentage, 6
+#COLUMNINFO = 9, %, Organische stof percentage, 7
+#COLUMNVOID = 1, -9999.99
+#COLUMNVOID = 2, -9999.99
+#COLUMNVOID = 3, -9999.99
+#COLUMNVOID = 4, -9999.99
+#COLUMNVOID = 5, -9999.99
+#COLUMNVOID = 6, -9999.99
+#COLUMNVOID = 7, -9999.99
+#COLUMNVOID = 8, -9999.99
+#COLUMNVOID = 9, -9999.99
+#LASTSCAN = 11
+#REPORTCODE = GEF-BORE-Report,1,0,0
+#MEASUREMENTCODE = Onbekend,-,-,-
+#TESTID = B00A0001
+#XYID = 31000,155000,463000
+#ZID = 31000,6.15
+#MEASUREMENTTEXT = 3, Dorp, plaatsnaam
+#MEASUREMENTTEXT = 6, beschrijver, beschrijver lagen
+#MEASUREMENTTEXT = 9, maaiveld, vast horizontaal niveau
+#MEASUREMENTTEXT = 13, Boorbedrijf, boorbedrijf
+#MEASUREMENTTEXT = 16, 1900-01-01, datum boring
+#MEASUREMENTTEXT = 31, PUL, boormethode
+#MEASUREMENTTEXT = 7, Rijksdriehoeksmeting, locaal coÃ¶rdinatensysteem
+#MEASUREMENTTEXT = 8, Normaal Amsterdams Peil, locaal referentiesysteem
+#MEASUREMENTVAR = 16, 12.00, m, einddiepte
+#MEASUREMENTTEXT = 14, Nee, openbaar
+#MEASUREMENTTEXT = 17, Onbekend, vochtigheidstoestand grond
+#MEASUREMENTTEXT = 18, Nee, peilbuis afwezig
+#EOH = 
+0.00;0.95;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Kz';'DO GR';!
+0.95;1.30;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zs1';'ON';'ZFC';!
+1.30;1.90;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Lz3';'LI GR';'CA2';!
+1.90;4.20;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zs';'LI TBR GR';'ZFC';'CA2';!
+4.20;6.45;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg1';'LI TBR GR';'ZMGO';'SMK';'ZAF';'FN2';'CA2';!
+6.45;7.25;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg';'LI TBR GR';'ZMGO';'SZG';'ZAF';'GG2';'CA2';!
+7.25;7.60;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zsg';'ON';!
+7.60;8.80;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg';'LI GR';'ZZGO';'SZG';'ZAF';'CA1';!
+8.80;10.20;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg3';'LI GR';'ZZGO';'FN2';'CA1';!
+10.20;10.90;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg';'LI GR';'ZZGO';'CA2';!
+10.90;12.00;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg2';'LI GR';'ZMGO';'SMA';'ZAF';'GG1';'CA2';!

--- a/tests/borehole-files/test_borehole_non_equal_description_field2.gef
+++ b/tests/borehole-files/test_borehole_non_equal_description_field2.gef
@@ -1,0 +1,56 @@
+#GEFID = 1,1,0
+#COLUMNTEXT = 1, aan
+#COLUMNSEPARATOR = ;
+#RECORDSEPARATOR = !
+#FILEOWNER = DINO
+#COMPANYID = Onbekend
+#FILEDATE = 2023,1,24
+#PROJECTID = DINO-BOR
+#COLUMN = 9
+#COLUMNINFO = 1, m, Diepte bovenkant laag, 1
+#COLUMNINFO = 2, m, Diepte onderkant laag, 2
+#COLUMNINFO = 3, mm, Zandmediaan, 8
+#COLUMNINFO = 4, mm, Grindmediaan, 9
+#COLUMNINFO = 5, %, Lutum percentage, 3
+#COLUMNINFO = 6, %, Silt percentage, 4
+#COLUMNINFO = 7, %, Zand percentage, 5
+#COLUMNINFO = 8, %, Grind percentage, 6
+#COLUMNINFO = 9, %, Organische stof percentage, 7
+#COLUMNVOID = 1, -9999.99
+#COLUMNVOID = 2, -9999.99
+#COLUMNVOID = 3, -9999.99
+#COLUMNVOID = 4, -9999.99
+#COLUMNVOID = 5, -9999.99
+#COLUMNVOID = 6, -9999.99
+#COLUMNVOID = 7, -9999.99
+#COLUMNVOID = 8, -9999.99
+#COLUMNVOID = 9, -9999.99
+#LASTSCAN = 10
+#REPORTCODE = GEF-BORE-Report,1,0,0
+#MEASUREMENTCODE = Onbekend,-,-,-
+#TESTID = B00A0001
+#XYID = 31000,155000,463000
+#ZID = 31000,7.45
+#MEASUREMENTTEXT = 3, Dorp, plaatsnaam
+#MEASUREMENTTEXT = 6, Beschrijver, beschrijver lagen
+#MEASUREMENTTEXT = 9, maaiveld, vast horizontaal niveau
+#MEASUREMENTTEXT = 13, Boordedrijf, boorbedrijf
+#MEASUREMENTTEXT = 16, 1932-01-01, datum boring
+#MEASUREMENTTEXT = 31, PUL, boormethode
+#MEASUREMENTTEXT = 7, Rijksdriehoeksmeting, locaal coÃ¶rdinatensysteem
+#MEASUREMENTTEXT = 8, Normaal Amsterdams Peil, locaal referentiesysteem
+#MEASUREMENTVAR = 16, 13.00, m, einddiepte
+#MEASUREMENTTEXT = 14, Nee, openbaar
+#MEASUREMENTTEXT = 17, Onbekend, vochtigheidstoestand grond
+#MEASUREMENTTEXT = 18, Nee, peilbuis afwezig
+#EOH = 
+0.00;1.15;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zs3';'LI TBR GR';'ZZFO';!
+1.15;2.00;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Lz';'LI TBR GR';'CA1';!
+2.00;3.50;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Lz3s3';'LI TBR GR';!
+3.50;5.00;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zs1g2';'LI TBR GR';'ZMGO';'SZG';'ZAF';'FN2';'CA2';!
+5.00;6.80;-9999.99;-9999.99;-9999.99;0.00;-9999.99;-9999.99;-9999.99;'Zg2';'LI TBR GR';'ZMGO';'FN2';!
+6.80;8.30;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg2';'GR';'ZGC';'GG1';!
+8.30;9.20;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg3';'GR';'ZZGO';'GG2';!
+9.20;10.90;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg2';'GR';'ZGC';'FN2';!
+10.90;12.10;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg3';'GR';'ZZGO';'GG2';'CA2';!
+12.10;13.00;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;-9999.99;'Zg1';'LI GR';'ZMGO';'SZK';'ZAF';'GG2';'CA2';!

--- a/tests/test_gefxml_reader.py
+++ b/tests/test_gefxml_reader.py
@@ -55,7 +55,8 @@ class TestGefXmlReader:
         print(bore.analyses)
         print(bore.complex_analyses)
         assert True
-        def test_borehole_non_equal_description_field(self):
+    
+    def test_borehole_non_equal_description_field(self):
         # Get path to test boreholes
         boreholes_path = Path(__file__).parent / "borehole-files"
 

--- a/tests/test_gefxml_reader.py
+++ b/tests/test_gefxml_reader.py
@@ -55,3 +55,22 @@ class TestGefXmlReader:
         print(bore.analyses)
         print(bore.complex_analyses)
         assert True
+        def test_borehole_non_equal_description_field(self):
+        # Get path to test boreholes
+        boreholes_path = Path(__file__).parent / "borehole-files"
+
+        # Test loading .gef file
+        path = boreholes_path / "test_borehole_non_equal_description_field.gef"
+        bh_gef = Bore()
+        bh_gef.load_gef(str(path))
+        assert True
+
+    def test_borehole_bug_non_equal_description_field2(self):
+        # Get path to test boreholes
+        boreholes_path = Path(__file__).parent / "borehole-files"
+
+        # Test loading .gef file
+        path = boreholes_path / "test_borehole_non_equal_description_field2.gef"
+        bh_gef = Bore()
+        bh_gef.load_gef(str(path))
+        assert True


### PR DESCRIPTION
Hello Thomas, 

When parsing, we encountered two bugs:
- if there is an empty line at the end of the file, the borehole descriptions cannot be parsed
- if the column separators in the descriptions are not all the same length, the description parsing fails

Both bugs are fixed in this PR. Florentine also made an issue about of this: https://github.com/ic144/geotexxx_package/issues/56.

The current solution for this is to just fill up the column separators so they are of equal length for every description. This way, pandas can parse the descriptions. We are neglecting the additional information described (I do not know what significance this information has).

I am curious what you think about the addition!

Kind regards,
Tom